### PR TITLE
Generate openapi docs and provide UI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ An application that allows a pinger to scan a QR code and a user to receive a no
 
 ## Howto
 
+### OpenAPI
+[OpenAPI UI - Explore and send requests](http://localhost:8080/swagger-ui.html)
+
+[OpenAPI Spec](http://localhost:8080/v3/api-docs/)
+
+
 ### Create a user
 ```bash
 curl -X POST http://localhost:8080/user/signup \
@@ -27,6 +33,6 @@ curl -X POST http://localhost:8080/user/signup \
   
 ### Ping a User
 ```bash
-curl -X GET http://localhost:8080/user/8 \
-  -H "Content-Type: application/json"
+curl -H "Content-Type: application/json" \
+  -X GET http://localhost:8080/user/{USER_ID} 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,11 @@ dependencies {
 	implementation group: "com.twilio.sdk", name: "twilio", version: "9.0.0"
 	implementation 'com.google.zxing:core:3.5.0'
 	implementation 'com.google.zxing:javase:3.5.0'
+
+	// OpenAPI Doc Gen and UI
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
+	implementation 'org.springdoc:springdoc-openapi-webmvc-core:1.6.11'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Generate openapi docs and provide UI page
Useful for dev, debugging, and documenting the API (if there will ever be a consumer)

<img width="1548" alt="image" src="https://user-images.githubusercontent.com/664513/195465508-df018cc2-a64e-45ae-8d6a-50586a968116.png">
