### PR TITLE
Upgrade to Junit 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,6 @@ out/
 .vscode/
 
 ## Credentials ##
-application.properties
+# application.properties
+
+lib/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ An application that allows a pinger to scan a QR code and a user to receive a no
 
 ## Howto
 
+### Setup Environment variables (or application.properties)
+
+| prop                 | sample value        | desc               |
+|----------------------|---------------------|--------------------|
+| SPRING_MAIL_PASSWORD | VERY_SECRET         | Pw from provider   |
+| SPRING_MAIL_USERNAME | qrpinger@sample.com | From email address | 
+| spring.mail.host     | smtp.gmail.com      | SMTP Server        |
+| text.strategy.twilio.sid | TWILIO_SID_BOGUS | ID for Twilio |
+| text.strategy.twilio.token | TWILIO_TOKEN_BOGUS | Twilio Token|
+| text.strategy.twilio.from_number | 5555551212 | SMS Comes from this # |
+
 ### Create a user
 ```bash
 curl -X POST http://localhost:8080/user/signup \

--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ An application that allows a pinger to scan a QR code and a user to receive a no
 
 ### Setup Environment variables (or application.properties)
 
-| prop                 | sample value        | desc               |
-|----------------------|---------------------|--------------------|
-| SPRING_MAIL_PASSWORD | VERY_SECRET         | Pw from provider   |
-| SPRING_MAIL_USERNAME | qrpinger@sample.com | From email address | 
-| spring.mail.host     | smtp.gmail.com      | SMTP Server        |
-| text.strategy.twilio.sid | TWILIO_SID_BOGUS | ID for Twilio |
-| text.strategy.twilio.token | TWILIO_TOKEN_BOGUS | Twilio Token|
+
+
+
+
+| prop                             | sample value | desc               |
+|----------------------------------|--------------|--------------------|
+| SPRING_DATASOURCE_USERNAME       | BOGUS        | DB User |
+| SPRING_DATASOURCE_PASSWORD       | ALSO_BOGUS | DB Pw| 
+| SPRING_MAIL_PASSWORD             | VERY_SECRET         | Pw from provider   |
+| SPRING_MAIL_USERNAME             | qrpinger@sample.com | From email address | 
+| spring.mail.host                 | smtp.gmail.com      | SMTP Server        |
+| text.strategy.twilio.sid         | TWILIO_SID_BOGUS | ID for Twilio |
+| text.strategy.twilio.token       | TWILIO_TOKEN_BOGUS | Twilio Token|
 | text.strategy.twilio.from_number | 5555551212 | SMS Comes from this # |
 
 ### Create a user

--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,19 @@ dependencies {
 	implementation group: "com.twilio.sdk", name: "twilio", version: "9.0.0"
 	implementation 'com.google.zxing:core:3.5.0'
 	implementation 'com.google.zxing:javase:3.5.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Testing. Use JUnit 5 and embedded, in-memory H2 database.
+	testImplementation('org.springframework.boot:spring-boot-starter-test:2.7.4') {
+		exclude group: 'junit', module: 'junit'
+	}
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+	testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/flight/qrpinger/domain/QRCode.java
+++ b/src/main/java/com/flight/qrpinger/domain/QRCode.java
@@ -22,7 +22,7 @@ public class QRCode {
     public QRCode(BitMatrix matrix, User user) {
         this.matrix = matrix;
         this.user = user;
-        this.path = Path.of(System.getProperty("java.io.tmpdir") + "\\" + user.getId());
+        this.path = Path.of(System.getProperty("java.io.tmpdir") + "/" + user.getId());
     }
 
     public File toFile() throws IOException {

--- a/src/main/java/com/flight/qrpinger/service/user/UserServiceImpl.java
+++ b/src/main/java/com/flight/qrpinger/service/user/UserServiceImpl.java
@@ -37,7 +37,7 @@ public class UserServiceImpl implements UserService {
         Optional<User> userOptional = userRepository.findById(id);
         if (!userOptional.isPresent()) {
             log.severe("No user with id [" + id + "] Throwing UserNotFoundException...");
-            throw new UserNotFoundException("No user with that id exists...");
+            throw new UserNotFoundException("No user with that id exists");
         }
 
         return userOptional.get();

--- a/src/test/java/com/flight/qrpinger/service/email/EmailServiceImplTest.java
+++ b/src/test/java/com/flight/qrpinger/service/email/EmailServiceImplTest.java
@@ -1,16 +1,44 @@
 package com.flight.qrpinger.service.email;
 
+import com.flight.qrpinger.domain.QRCode;
+import com.flight.qrpinger.domain.User;
+import com.flight.qrpinger.exceptions.FailedToEmailException;
+import com.flight.qrpinger.service.qrgen.QRServiceImpl;
+import com.google.zxing.WriterException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@SpringBootTest
 class EmailServiceImplTest {
+    @Autowired
+    private QRServiceImpl qrService;
+
+    @Autowired
+    private EmailServiceImpl emailService;
 
     @BeforeEach
     void setUp() {
     }
 
     @Test
-    void sendEmail() {
-
+    void gotService() {
+        org.junit.jupiter.api.Assertions.assertNotNull(emailService);
     }
+
+    @Test
+    void sendEmail() {
+        assertDoesNotThrow(() -> {
+            var user = User.builder().email("bogus@bogus.bogus").build();
+            var qrCode = qrService.generate(user);
+
+            emailService.sendEmail(user, "test", "test body", qrCode);
+        });
+    }
+
 }

--- a/src/test/java/com/flight/qrpinger/service/qrgen/QRServiceImplTest.java
+++ b/src/test/java/com/flight/qrpinger/service/qrgen/QRServiceImplTest.java
@@ -5,13 +5,17 @@ import com.flight.qrpinger.domain.User;
 import com.google.zxing.WriterException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest
 class QRServiceImplTest {
 
+    @Autowired
     private QRServiceImpl qrService;
 
     @BeforeEach
@@ -32,7 +36,7 @@ class QRServiceImplTest {
         QRCode actual = qrService.generate(expectedUser);
 
         assertEquals(actual.getUser(), expectedUser);
-        assertEquals(actual.getPath(), expectedPath);
+        assertEquals(actual.getPath().toString(), expectedPath.toString());
         assertNotNull(actual.getMatrix());
     }
 }

--- a/src/test/java/com/flight/qrpinger/service/sms/TextServiceImplTest.java
+++ b/src/test/java/com/flight/qrpinger/service/sms/TextServiceImplTest.java
@@ -4,15 +4,18 @@ import com.flight.qrpinger.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+@SpringBootTest
 class TextServiceImplTest {
 
+    @Autowired
     private TextServiceImpl textService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        textService = new TextServiceImpl();
     }
 
     @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,33 @@
+# Spring & PostgreSQL
+server.port=8080
+#spring.datasource.url={$DB_URL}
+spring.datasource.url=jdbc:h2:mem:testdb
+#spring.datasource.username=${DB_USERNAME}
+spring.datasource.username=BOGUS
+#spring.datasource.password=${DB_PASSWORD}
+spring.datasource.password=ALSO_BOGUS
+
+spring.datasource.hikari.connectionTimeout=20000
+spring.datasource.hikari.maximumPoolSize=5
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+
+# Spring & Java Mail Sender
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${EMAIL}
+spring.mail.password=${PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+# text.strategy: TextStrategyNone or TextStrategyTwilio
+text.strategy=TextStrategyNone
+text.strategy.twilio.sid=TWILIO_SID_BOGUS
+text.strategy.twilio.token=TWILIO_TOKEN_BOGUS
+text.strategy.twilio.from_number=5555551212
+
+qr.base_url=http://localhost:8080/

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,9 +2,7 @@
 server.port=8080
 #spring.datasource.url={$DB_URL}
 spring.datasource.url=jdbc:h2:mem:testdb
-#spring.datasource.username=${DB_USERNAME}
 spring.datasource.username=BOGUS
-#spring.datasource.password=${DB_PASSWORD}
 spring.datasource.password=ALSO_BOGUS
 
 spring.datasource.hikari.connectionTimeout=20000
@@ -19,8 +17,6 @@ spring.jpa.show-sql=false
 # Spring & Java Mail Sender
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
-spring.mail.username=${EMAIL}
-spring.mail.password=${PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,9 +1,6 @@
 # Spring & PostgreSQL
 server.port=8080
-#spring.datasource.url={$DB_URL}
 spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.username=BOGUS
-spring.datasource.password=ALSO_BOGUS
 
 spring.datasource.hikari.connectionTimeout=20000
 spring.datasource.hikari.maximumPoolSize=5


### PR DESCRIPTION
Upgrade to Unit 5
Fix unit tests
Use h2 database for running tests rather than postgresql. Don't have to have a postgresql database server running to run tests and data from tests doesn't pollute the official database.